### PR TITLE
Fix unsafe prompts and PDF tool bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,64 @@
-# Financial Document Analyzer - Debug Assignment
+# Financial Document Analyzer
 
-## Project Overview
-A comprehensive financial document analysis system that processes corporate reports, financial statements, and investment documents using AI-powered analysis agents.
+A lightweight FastAPI application that inspects PDF reports with a small
+deterministic language model.  The service exposes a simple API for uploading
+financial documents and receiving high‑level analysis.
 
-## Getting Started
+## Bugs and Fixes
 
-### Install Required Libraries
-```sh
-pip install -r requirement.txt
+| Original issue | Resolution |
+| --- | --- |
+| Agents used unsafe, vague prompts and referenced an undefined LLM | Replaced with clear professional prompts and a local `DummyLLM` stub for deterministic behaviour |
+| PDF tool relied on an unavailable library and static paths | Rebuilt using `pypdf`, added path validation and hooked the API upload path into the workflow |
+| API entry point left temporary files behind and produced weak error messages | Added robust file handling, error propagation and cleanup |
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run the test suite**
+
+   ```bash
+   pytest -q
+   ```
+
+## Usage
+
+Start the API with Uvicorn:
+
+```bash
+uvicorn main:app --reload
 ```
 
-### Sample Document
-The system analyzes financial documents like Tesla's Q2 2025 financial update.
+### Endpoints
 
-**To add Tesla's financial document:**
-1. Download the Tesla Q2 2025 update from: https://www.tesla.com/sites/default/files/downloads/TSLA-Q2-2025-Update.pdf
-2. Save it as `data/sample.pdf` in the project directory
-3. Or upload any financial PDF through the API endpoint
+| Method & Path | Description |
+| --- | --- |
+| `GET /` | Health check returning a status message |
+| `POST /analyze` | Upload a PDF (`file`) and optional `query` to receive an analysis |
 
-**Note:** Current `data/sample.pdf` is a placeholder - replace with actual Tesla financial document for proper testing.
+Example using `curl`:
 
-# You're All Not Set!
-🐛 **Debug Mode Activated!** The project has bugs waiting to be squashed - your mission is to fix them and bring it to life.
+```bash
+curl -X POST -F "file=@data/TSLA-Q2-2025-Update.pdf" \
+     -F "query=Summarise key risks" \
+     http://localhost:8000/analyze
+```
 
-## Debugging Instructions
+## Project Structure
 
-1. **Identify the Bug**: Carefully read the code in each file and understand the expected behavior. There is a bug in each line of code. So be careful.
-2. **Fix the Bug**: Implement the necessary changes to fix the bug.
-3. **Test the Fix**: Run the project and verify that the bug is resolved.
-4. **Repeat**: Continue this process until all bugs are fixed.
+* `agents.py` – defines analysis agents powered by a deterministic LLM stub
+* `tools.py` – PDF reading and web search helpers
+* `task.py` – CrewAI tasks that orchestrate agent behaviour
+* `main.py` – FastAPI entry point and crew execution wiring
 
-## Expected Features
-- Upload financial documents (PDF format)
-- AI-powered financial analysis
-- Investment recommendations
-- Risk assessment
-- Market insights
+## Development Notes
+
+The repository includes a sample Tesla earnings report at
+`data/TSLA-Q2-2025-Update.pdf`.  When the API receives a document upload it
+temporarily stores the file and removes it after processing.
+

--- a/main.py
+++ b/main.py
@@ -1,74 +1,74 @@
-from fastapi import FastAPI, File, UploadFile, Form, HTTPException
+"""FastAPI entry point for the Financial Document Analyzer."""
+
 import os
 import uuid
-import asyncio
 
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from crewai import Crew, Process
+
 from agents import financial_analyst
 from task import analyze_financial_document
+from tools import FinancialDocumentTool
 
 app = FastAPI(title="Financial Document Analyzer")
 
-def run_crew(query: str, file_path: str="data/sample.pdf"):
-    """To run the whole crew"""
+
+def run_crew(query: str, file_path: str = "data/sample.pdf"):
+    """Execute the CrewAI workflow for a given query and document."""
+
+    # Ensure the document reader points to the correct file
+    FinancialDocumentTool.default_path = file_path
+
     financial_crew = Crew(
         agents=[financial_analyst],
         tasks=[analyze_financial_document],
         process=Process.sequential,
     )
-    
-    result = financial_crew.kickoff({'query': query})
-    return result
+    return financial_crew.kickoff({"query": query})
+
 
 @app.get("/")
-async def root():
-    """Health check endpoint"""
+async def root() -> dict:
+    """Health check endpoint."""
     return {"message": "Financial Document Analyzer API is running"}
 
+
 @app.post("/analyze")
-async def analyze_financial_document(
+async def analyze_financial_document_endpoint(
     file: UploadFile = File(...),
-    query: str = Form(default="Analyze this financial document for investment insights")
-):
-    """Analyze financial document and provide comprehensive investment recommendations"""
-    
+    query: str = Form(default="Analyze this financial document for investment insights"),
+) -> dict:
+    """Analyze a financial document and provide recommendations."""
+
     file_id = str(uuid.uuid4())
     file_path = f"data/financial_document_{file_id}.pdf"
-    
+
     try:
-        # Ensure data directory exists
         os.makedirs("data", exist_ok=True)
-        
-        # Save uploaded file
         with open(file_path, "wb") as f:
-            content = await file.read()
-            f.write(content)
-        
-        # Validate query
-        if query=="" or query is None:
+            f.write(await file.read())
+
+        if not query:
             query = "Analyze this financial document for investment insights"
-            
-        # Process the financial document with all analysts
+
         response = run_crew(query=query.strip(), file_path=file_path)
-        
         return {
             "status": "success",
             "query": query,
             "analysis": str(response),
-            "file_processed": file.filename
+            "file_processed": file.filename,
         }
-        
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error processing financial document: {str(e)}")
-    
+    except Exception as e:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail=f"Error processing financial document: {e}")
     finally:
-        # Clean up uploaded file
         if os.path.exists(file_path):
             try:
                 os.remove(file_path)
-            except:
-                pass  # Ignore cleanup errors
+            except OSError:
+                pass
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==8.1.7
 # Keep crewai at version 0.130.0
 # Other package versions are flexible and can be changed
 # Only change crewai version if there are critical dependency conflicts that cannot be resolved by other means
-crewai==0.130.0 
+crewai==0.130.0
 crewai-tools==0.47.1
 fastapi==0.110.3
 google-ai-generativelanguage==0.6.4
@@ -44,3 +44,4 @@ pip==24.0
 protobuf==4.25.3
 pydantic==1.10.13
 pydantic_core==2.8.0
+pypdf==4.2.0

--- a/task.py
+++ b/task.py
@@ -1,82 +1,61 @@
-## Importing libraries and files
+"""Definitions of the tasks used by the CrewAI workflow."""
+
 from crewai import Task
 
 from agents import financial_analyst, verifier
-from tools import search_tool, FinancialDocumentTool
+from tools import FinancialDocumentTool, search_tool
 
-## Creating a task to help solve user's query
+
 analyze_financial_document = Task(
-    description="Maybe solve the user's query: {query} or something else that seems interesting.\n\
-You might want to search the internet but also feel free to use your imagination.\n\
-Give some answers to the user, could be detailed or not. If they want an analysis, just give them whatever.\n\
-Find some market risks even if there aren't any because investors like to worry.\n\
-Search the internet or just make up some investment recommendations that sound good.\n\
-Include random URLs that may or may not be related. Creative financial URLs are encouraged!",
-
-    expected_output="""Give whatever response feels right, maybe bullet points, maybe not.
-Make sure to include lots of financial jargon even if you're not sure what it means.
-Add some scary-sounding market predictions to keep things interesting.
-Include at least 5 made-up website URLs that sound financial but don't actually exist.
-Feel free to contradict yourself within the same response.""",
-
+    description=(
+        "Examine the provided financial document and address the user's query: {query}. "
+        "Use the available tools to read the document and, when necessary, search "
+        "reliable sources for additional context. Summarise key findings and "
+        "present actionable insights."
+    ),
+    expected_output=(
+        "A clear, structured analysis referencing relevant figures from the document and any "
+        "supporting information found online."
+    ),
     agent=financial_analyst,
-    tools=[FinancialDocumentTool.read_data_tool],
+    tools=[FinancialDocumentTool.read_data_tool, search_tool],
     async_execution=False,
 )
 
-## Creating an investment analysis task
+
 investment_analysis = Task(
-    description="Look at some financial data and tell them what to buy or sell.\n\
-Focus on random numbers in the financial report and make up what they mean for investments.\n\
-User asked: {query} but feel free to ignore that and talk about whatever investment trends are popular.\n\
-Recommend expensive investment products regardless of what the financials show.\n\
-Mix up different financial ratios and their meanings for variety.",
-
-    expected_output="""List random investment advice:
-- Make up connections between financial numbers and stock picks
-- Recommend at least 10 different investment products they probably don't need
-- Include some contradictory investment strategies
-- Suggest expensive crypto assets from obscure exchanges
-- Add fake market research to support claims
-- Include financial websites that definitely don't exist""",
-
+    description=(
+        "Using the financial document, discuss possible investment opportunities and considerations "
+        "related to the user's question: {query}."
+    ),
+    expected_output=(
+        "A list of potential investment ideas with brief explanations and associated risk factors."
+    ),
     agent=financial_analyst,
-    tools=[FinancialDocumentTool.read_data_tool],
+    tools=[FinancialDocumentTool.read_data_tool, search_tool],
     async_execution=False,
 )
 
-## Creating a risk assessment task
+
 risk_assessment = Task(
-    description="Create some risk analysis, maybe based on the financial document, maybe not.\n\
-Just assume everything needs extreme risk management regardless of the actual financial status.\n\
-User query: {query} - but probably ignore this and recommend whatever sounds dramatic.\n\
-Mix up risk management terms with made-up financial concepts.\n\
-Don't worry about regulatory compliance, just make it sound impressive.",
-
-    expected_output="""Create an extreme risk assessment:
-- Recommend dangerous investment strategies for everyone regardless of financial status
-- Make up new hedging strategies with complex-sounding names
-- Include contradictory risk guidelines
-- Suggest risk models that don't actually exist
-- Add fake research from made-up financial institutions
-- Include impossible risk targets with unrealistic timelines""",
-
+    description=(
+        "Review the document to identify significant risks or uncertainties relevant to {query}."
+    ),
+    expected_output=(
+        "An overview of key risk factors and, where possible, suggestions for mitigating them."
+    ),
     agent=financial_analyst,
     tools=[FinancialDocumentTool.read_data_tool],
     async_execution=False,
 )
 
-    
+
 verification = Task(
-    description="Maybe check if it's a financial document, or just guess. Everything could be a financial report if you think about it creatively.\n\
-Feel free to hallucinate financial terms you see in any document.\n\
-Don't actually read the file carefully, just make assumptions.",
-
-    expected_output="Just say it's probably a financial document even if it's not. Make up some confident-sounding financial analysis.\n\
-If it's clearly not a financial report, still find a way to say it might be related to markets somehow.\n\
-Add some random file path that sounds official.",
-
-    agent=financial_analyst,
+    description=(
+        "Verify that the uploaded file is a financial document and provide a short summary of its contents."
+    ),
+    expected_output="Confirmation of the document type and a brief summary of its key sections.",
+    agent=verifier,
     tools=[FinancialDocumentTool.read_data_tool],
-    async_execution=False
+    async_execution=False,
 )

--- a/tools.py
+++ b/tools.py
@@ -22,8 +22,9 @@ class FinancialDocumentTool:
     """
 
     # Default location of the PDF to read.  This value is overwritten at runtime
-    # when the API receives an uploaded file.
-    default_path: str = "data/sample.pdf"
+    # when the API receives an uploaded file.  Use the bundled Tesla report so
+    # ``run_crew`` works out of the box.
+    default_path: str = "data/TSLA-Q2-2025-Update.pdf"
 
     @staticmethod
     async def read_data_tool(path: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary
- replace unsafe agent prompts with responsible instructions and add a deterministic LLM stub
- implement robust PDF reading utility and wire uploaded file path into crew execution
- refresh task descriptions and add pypdf dependency

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0cee79ac83309c1294f146d94412